### PR TITLE
feature: Add major event placeholder + fix timeline separators and borders for active elements

### DIFF
--- a/src/Timeline.css
+++ b/src/Timeline.css
@@ -24,12 +24,19 @@ body {
     transition: background-color 0.3s ease;
 }
 
+  .timeline-content > h3 {
+    color: #c10101;
+    font-size: 1.5em;
+    margin: 0;
+  }
+
 .timeline-separator {
     content: '';
     width: 6px;
     background-color: #009688;
     justify-self: center;
     height: 30px;
+    border-radius: 4px;
 }
 
 .timeline-item.active.left {

--- a/src/Timeline.css
+++ b/src/Timeline.css
@@ -1,18 +1,18 @@
 /* src/Timeline.css */
 body {
     font-family: Arial, sans-serif;
-  }
-  
-  .timeline {
+}
+
+.timeline {
     position: relative;
     max-width: 800px;
     margin: 0 auto;
     padding: 20px 0;
     color: #333;
     display: grid;
-  }
-  
-  .timeline-item {
+}
+
+.timeline-item {
     padding: 10px 20px;
     margin: 20px 0;
     background: #f9f9f9;
@@ -24,11 +24,11 @@ body {
     transition: background-color 0.3s ease;
 }
 
-  .timeline-content > h3 {
+.timeline-content > h3 {
     color: #c10101;
     font-size: 1.5em;
     margin: 0;
-  }
+}
 
 .timeline-separator {
     content: '';
@@ -92,33 +92,40 @@ body {
     }
 
     .timeline-item.left {
-      justify-self: flex-start;
-      clear: both;
-      margin-left: -12px;
+        justify-self: flex-start;
+        clear: both;
+        margin-left: -12px;
     }
-  
+
     .timeline-item.right {
-      justify-self: flex-end;
-      clear: both;
-      margin-right: -12px;
+        justify-self: flex-end;
+        clear: both;
+        margin-right: -12px;
     }
-  }
-  
-  /* Small screens (phones, up to 767px) */
-  @media (max-width: 767px) {
+}
+
+/* Small screens (phones, up to 767px) */
+@media (max-width: 767px) {
     .timeline-item {
-      width: 90%;
-      float: none;
-      clear: both;
-      transform: translateX(0);
-      margin-left: auto;
-      margin-right: auto;
+        width: 90%;
+        float: none;
+        clear: both;
+        transform: translateX(0);
+        margin-left: auto;
+        margin-right: auto;
     }
-  
+
     .timeline-item.left::before,
     .timeline-item.right::before {
-      left: 50%;
-      transform: translateX(-50%);
+        left: 50%;
+        transform: translateX(-50%);
     }
-  }
+
+    .timeline-item.left.active,
+    .timeline-item.right.active {
+        background-color: #e0f7fa;
+        border-left: 4px solid #009688;
+        border-right: 4px solid #009688;
+    }
+}
   

--- a/src/Timeline.css
+++ b/src/Timeline.css
@@ -9,6 +9,7 @@ body {
     margin: 0 auto;
     padding: 20px 0;
     color: #333;
+    display: grid;
   }
   
   .timeline-item {
@@ -21,15 +22,28 @@ body {
     width: 90%;
     clear: both;
     transition: background-color 0.3s ease;
-  }
-  
-  .timeline-item.active {
+}
+
+.timeline-separator {
+    content: '';
+    width: 6px;
+    background-color: #009688;
+    justify-self: center;
+    height: 30px;
+}
+
+.timeline-item.active.left {
+    background-color: #e0f7fa;
+    border-right: 4px solid #009688;
+}
+
+.timeline-item.active.right {
     background-color: #e0f7fa;
     border-left: 4px solid #009688;
-  }
-  
-  .timeline-item.left::before,
-  .timeline-item.right::before {
+}
+
+.timeline-item.left::before,
+.timeline-item.right::before {
     content: '';
     position: absolute;
     top: 15px;
@@ -38,59 +52,46 @@ body {
     background: #f9f9f9;
     border: 4px solid #009688;
     border-radius: 50%;
-  }
-  
-  .timeline-item.left::before {
+}
+
+.timeline-item.left::before {
     right: -12px;
-  }
-  
-  .timeline-item.right::before {
+}
+
+.timeline-item.right::before {
     left: -12px;
-  }
-  
-  .timeline-content {
+}
+
+.timeline-content {
     padding: 20px;
     background: white;
     border-radius: 8px;
     position: relative;
-  }
-  
-  .timeline-content h2 {
+}
+
+.timeline-content h2 {
     margin: 0;
     color: #009688;
-  }
-  
-  .timeline-content p {
+}
+
+.timeline-content p {
     margin: 8px 0;
-  }
-  
-  .timeline::after {
-    content: '';
-    position: absolute;
-    width: 6px;
-    background-color: #009688;
-    top: 0;
-    bottom: 0;
-    left: 50%;
-    margin-left: -3px;
-  }
-  
-  /* Medium screens (tablets, 768px and up) */
-  @media (min-width: 768px) {
+}
+
+/* Medium screens (tablets, 768px and up) */
+@media (min-width: 768px) {
     .timeline-item {
-      width: 45%;
+        width: 45%;
     }
-  
+
     .timeline-item.left {
-      float: left;
+      justify-self: flex-start;
       clear: both;
-      transform: translateX(-50%);
     }
   
     .timeline-item.right {
-      float: right;
+      justify-self: flex-end;
       clear: both;
-      transform: translateX(50%);
     }
   }
   

--- a/src/Timeline.css
+++ b/src/Timeline.css
@@ -87,11 +87,13 @@ body {
     .timeline-item.left {
       justify-self: flex-start;
       clear: both;
+      margin-left: -12px;
     }
   
     .timeline-item.right {
       justify-self: flex-end;
       clear: both;
+      margin-right: -12px;
     }
   }
   

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -18,7 +18,7 @@ interface Event {
 
 const Timeline: React.FC = () => {
   const [events, setEvents] = useState<Event[]>([]);
-  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [activeIndex, setActiveIndex] = useState<number | null>(0);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -53,6 +53,7 @@ const Timeline: React.FC = () => {
   return (
     <div className="timeline">
       {events.map((event, index) => (
+          <>
         <div
           key={event.report_date}
           className={`timeline-item ${index % 2 === 0 ? 'left' : 'right'} ${index === activeIndex ? 'active' : ''}`}
@@ -69,6 +70,8 @@ const Timeline: React.FC = () => {
             <p>Press Killed: {event.ext_press_killed_cum ?? 'N/A'}</p>
           </div>
         </div>
+          <div className="timeline-separator" />
+          </>
       ))}
     </div>
   );

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -70,7 +70,7 @@ const Timeline: React.FC = () => {
             <p>Press Killed: {event.ext_press_killed_cum ?? 'N/A'}</p>
           </div>
         </div>
-          <div className="timeline-separator" />
+        { index !== events.length - 1 && <div className="timeline-separator" /> }
           </>
       ))}
     </div>

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -14,6 +14,7 @@ interface Event {
   ext_civdef_killed_cum?: number;
   ext_med_killed_cum?: number;
   ext_press_killed_cum?: number;
+  major_event?: string;
 }
 
 const Timeline: React.FC = () => {
@@ -60,6 +61,7 @@ const Timeline: React.FC = () => {
         >
           <div className="timeline-content">
             <h2>{event.report_date}</h2>
+            {event.major_event && <h3>{event.major_event}</h3>}
             <p>Killed: {event.ext_killed ?? 'N/A'}</p>
             <p>Injured: {event.ext_injured ?? 'N/A'}</p>
             <p>Total Killed: {event.ext_killed_cum ?? 'N/A'}</p>

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -1,82 +1,93 @@
 // src/Timeline.tsx
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import axios from 'axios';
 import './Timeline.css';
 
 interface Event {
-  report_date: string;
-  ext_killed?: number;
-  ext_injured?: number;
-  ext_killed_cum?: number;
-  ext_injured_cum?: number;
-  ext_killed_children_cum?: number;
-  ext_killed_women_cum?: number;
-  ext_civdef_killed_cum?: number;
-  ext_med_killed_cum?: number;
-  ext_press_killed_cum?: number;
-  major_event?: string;
+    report_date: string;
+    ext_killed?: number;
+    ext_injured?: number;
+    ext_killed_cum?: number;
+    ext_injured_cum?: number;
+    ext_killed_children_cum?: number;
+    ext_killed_women_cum?: number;
+    ext_civdef_killed_cum?: number;
+    ext_med_killed_cum?: number;
+    ext_press_killed_cum?: number;
+    major_event?: string;
 }
 
 const Timeline: React.FC = () => {
-  const [events, setEvents] = useState<Event[]>([]);
-  const [activeIndex, setActiveIndex] = useState<number | null>(0);
+    const [events, setEvents] = useState<Event[]>([]);
+    const [activeIndex, setActiveIndex] = useState<number | null>(0);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await axios.get<Event[]>(
-          'https://data.techforpalestine.org/api/v2/casualties_daily.json'
-        );
-        setEvents(response.data.reverse()); // Reverse the data here
-      } catch (error) {
-        console.error('Error fetching the data', error);
-      }
-    };
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const response = await axios.get<Event[]>(
+                    'https://data.techforpalestine.org/api/v2/casualties_daily.json'
+                );
+                setEvents(response.data.reverse()); // Reverse the data here
+            } catch (error) {
+                console.error('Error fetching the data', error);
+            }
+        };
 
-    fetchData();
+        fetchData();
 
-    const handleScroll = () => {
-      const items = document.querySelectorAll('.timeline-item');
-      let index = 0;
-      items.forEach((item, i) => {
-        const rect = item.getBoundingClientRect();
-        if (rect.top <= window.innerHeight / 2 && rect.bottom >= window.innerHeight / 2) {
-          index = i;
+        const debounce = (func: () => void, delay: number) => {
+            let timeout: number;
+            return () => {
+                clearTimeout(timeout);
+                timeout = window.setTimeout(func, delay);
+            };
         }
-      });
-      setActiveIndex(index);
-    };
 
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
+        const handleScroll = () => {
+            console.log('scroll');
+            const items = document.querySelectorAll('.timeline-item');
+            let index = 0;
+            items.forEach((item, i) => {
+                const rect = item.getBoundingClientRect();
+                if (rect.top <= window.innerHeight / 2 && rect.bottom >= window.innerHeight / 2) {
+                    index = i;
+                }
+            });
+            setActiveIndex(index);
+        };
 
-  return (
-    <div className="timeline">
-      {events.map((event, index) => (
-          <>
-        <div
-          key={event.report_date}
-          className={`timeline-item ${index % 2 === 0 ? 'left' : 'right'} ${index === activeIndex ? 'active' : ''}`}
-        >
-          <div className="timeline-content">
-            <h2>{event.report_date}</h2>
-            {event.major_event && <h3>{event.major_event}</h3>}
-            <p>Killed: {event.ext_killed ?? 'N/A'}</p>
-            <p>Injured: {event.ext_injured ?? 'N/A'}</p>
-            <p>Total Killed: {event.ext_killed_cum ?? 'N/A'}</p>
-            <p>Total Injured: {event.ext_injured_cum ?? 'N/A'}</p>
-            <p>Children Killed: {event.ext_killed_children_cum ?? 'N/A'}</p>
-            <p>Women Killed: {event.ext_killed_women_cum ?? 'N/A'}</p>
-            <p>Medics Killed: {event.ext_med_killed_cum ?? 'N/A'}</p>
-            <p>Press Killed: {event.ext_press_killed_cum ?? 'N/A'}</p>
-          </div>
+        const handleWithDebounce = debounce(handleScroll, 50);
+
+        window.addEventListener('scroll', handleWithDebounce);
+        return () => window.removeEventListener('scroll', handleWithDebounce);
+    }, []);
+
+    return (
+        <div className="timeline">
+            {events.map((event, index) => (
+                <>
+                    <div
+                        key={event.report_date}
+                        className={`timeline-item ${index % 2 === 0 ? 'left' : 'right'} ${index === activeIndex ? 'active' : ''}`}
+                    >
+                        <div className="timeline-content">
+                            <h2>{event.report_date}</h2>
+                            {event.major_event && <h3>{event.major_event}</h3>}
+                            <p>Killed: {event.ext_killed ?? 'N/A'}</p>
+                            <p>Injured: {event.ext_injured ?? 'N/A'}</p>
+                            <p>Total Killed: {event.ext_killed_cum ?? 'N/A'}</p>
+                            <p>Total Injured: {event.ext_injured_cum ?? 'N/A'}</p>
+                            <p>Children Killed: {event.ext_killed_children_cum ?? 'N/A'}</p>
+                            <p>Women Killed: {event.ext_killed_women_cum ?? 'N/A'}</p>
+                            <p>Medics Killed: {event.ext_med_killed_cum ?? 'N/A'}</p>
+                            <p>Press Killed: {event.ext_press_killed_cum ?? 'N/A'}</p>
+                        </div>
+                    </div>
+                    {index !== events.length - 1 && <div className="timeline-separator"/>}
+                </>
+            ))}
         </div>
-        { index !== events.length - 1 && <div className="timeline-separator" /> }
-          </>
-      ))}
-    </div>
-  );
+    );
 };
 
 export default Timeline;


### PR DESCRIPTION
### What was done
- Use grid layout and justifying items to set the location of each item
- Use separator divs that set the line between items
- Change behavior for active borders for mobile + web views
- Add placeholder for major_event variable
- Add debounce behavior for scroll handler to avoid too much computation


### 📸 Visual
![ScreenRecording2024-06-08at9 08 33PM-ezgif com-video-to-gif-converter](https://github.com/egytech-fyi/daysofagenocide/assets/13081893/d309eec9-0664-4732-b0cb-eab8d9a222dc)

### Major Event example:
<img width="495" alt="Screenshot 2024-06-08 at 10 49 36 PM" src="https://github.com/egytech-fyi/daysofagenocide/assets/13081893/dcfa741a-e81e-4113-9a8b-f0ae6ac22945">

### Mobile Look:
<img width="612" alt="Screenshot 2024-06-08 at 10 54 23 PM" src="https://github.com/egytech-fyi/daysofagenocide/assets/13081893/c0a47bb6-1f68-4efe-8f67-e919e377dd73">

