### PR TITLE
chore: cleanup use of query selectors

### DIFF
--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -1,21 +1,25 @@
-import React, {useState} from 'react';
+import React, {useRef, useState} from 'react';
 import './Timeline.css';
 import {CasualtyEvent} from "./models/casualty-event.model.ts";
 import {TimelineItem} from "./components/timeline-item.tsx";
 import {useCasualtyEvents} from "./hooks/use-casualty-events.ts";
 import {useSetActiveIndex} from "./hooks/use-set-active-index.ts";
+import {useSetItemRefs} from "./hooks/use-set-item-refs.ts";
 
 const Timeline: React.FC = () => {
     const [events, setEvents] = useState<CasualtyEvent[]>([]);
     const [activeIndex, setActiveIndex] = useState<number | null>(0);
+    const refs = useRef([] as HTMLDivElement[]);
 
+    useSetItemRefs(refs, events);
     useCasualtyEvents(setEvents);
-    useSetActiveIndex(events, setActiveIndex);
+    useSetActiveIndex(refs.current, setActiveIndex);
 
     return (
         <div className="timeline">
             {events.map((event, index) => (
                 <TimelineItem key={event.report_date} event={event} direction={index % 2 === 0 ? 'left' : 'right'}
+                              setRef={(node) => refs.current[index] = node}
                               active={activeIndex === index} withSeparator={index !== events.length - 1}/>
             ))}
         </div>

--- a/src/components/timeline-item.tsx
+++ b/src/components/timeline-item.tsx
@@ -7,14 +7,16 @@ interface Props {
     direction: 'left' | 'right';
     active: boolean;
     withSeparator: boolean;
+    setRef: (node: HTMLDivElement) => void;
 }
 
-export const TimelineItem: React.FC<Props> = ({event, direction, active, withSeparator}: Props) => {
+export const TimelineItem: React.FC<Props> = ({event, direction, active, withSeparator, setRef}: Props) => {
     return (
         <>
             <div
                 key={event.report_date}
                 className={`timeline-item ${direction} ${active ? 'active' : ''}`}
+                ref={setRef}
             >
                 <div className="timeline-content">
                     <h2>{event.report_date}</h2>

--- a/src/hooks/use-set-active-index.ts
+++ b/src/hooks/use-set-active-index.ts
@@ -1,16 +1,12 @@
 import {useEffect} from "react";
 import {debounce} from "../utils/debounce.ts";
 
-export const useSetActiveIndex = (events: unknown[], setActiveIndex: React.Dispatch<number>) => {
+export const useSetActiveIndex = (refs: HTMLDivElement[], setActiveIndex: React.Dispatch<number>) => {
     useEffect(() => {
-        const items = document.querySelectorAll('.timeline-item');
         const handleScroll = () => {
-            let index = 0;
-            items.forEach((item, i) => {
+            let index = refs.findIndex((item) => {
                 const rect = item.getBoundingClientRect();
-                if (rect.top <= window.innerHeight / 2 && rect.bottom >= window.innerHeight / 2) {
-                    index = i;
-                }
+                return rect.top <= window.innerHeight / 2 && rect.bottom >= window.innerHeight / 2;
             });
             setActiveIndex(index);
         };
@@ -19,5 +15,5 @@ export const useSetActiveIndex = (events: unknown[], setActiveIndex: React.Dispa
 
         window.addEventListener('scroll', handleWithDebounce);
         return () => window.removeEventListener('scroll', handleWithDebounce);
-    }, [events, setActiveIndex]);
+    }, [refs, setActiveIndex]);
 }

--- a/src/hooks/use-set-item-refs.ts
+++ b/src/hooks/use-set-item-refs.ts
@@ -1,0 +1,7 @@
+import {useEffect} from "react";
+
+export const useSetItemRefs = (refs: React.MutableRefObject<HTMLDivElement[]>, events: unknown[]) => {
+    useEffect(() => {
+        refs.current = refs.current.slice(0, events.length);
+    }, [events]);
+}


### PR DESCRIPTION
### What was done:
- use react refs instead of query selectors
- create refs from inside timeline-item
- exit the loop once an element matches